### PR TITLE
Image comp for collection page, fix cdn url

### DIFF
--- a/packages/kauri-components/components/Headers/CollectionHeader.tsx
+++ b/packages/kauri-components/components/Headers/CollectionHeader.tsx
@@ -16,9 +16,10 @@ const CollectionHeaderSection = styled.section`
   width: 100%;
   flex-direction: row;
   z-index: 1;
+  padding: ${props => props.theme.space[4] + 40}px
+    ${props => props.theme.padding} ${props => props.theme.space[4]}px;
   @media (max-width: 500px) {
     flex-direction: column;
-    padding: ${props => props.theme.space[1]}px;
   }
 `;
 
@@ -32,6 +33,9 @@ const LeftSide = styled.div`
   }
   > :last-child {
     margin-top: ${props => props.theme.space[2]}px;
+  }
+  @media (max-width: 500px) {
+    padding: ${props => props.theme.space[1]}px;
   }
 `;
 

--- a/packages/kauri-components/components/Image/index.tsx
+++ b/packages/kauri-components/components/Image/index.tsx
@@ -31,19 +31,19 @@ const getURL = (
     if (heightParam && !widthParam) {
       return `https://${
         process.env.cloudImageId
-      }.cloudimg.io/crop/2560x${heightParam}/webp-lossy-90/${url}`;
+      }.cloudimg.io/crop/2560x${heightParam}/twebp/${url}`;
     } else if (widthParam && !heightParam) {
       return `https://${
         process.env.cloudImageId
-      }.cloudimg.io/widthParam/${widthParam}/webp-lossy-90/${url}`;
+      }.cloudimg.io/widthParam/${widthParam}/twebp/${url}`;
     } else if (widthParam && heightParam) {
       return `https://${
         process.env.cloudImageId
-      }.cloudimg.io/crop/${widthParam}x${heightParam}/webp-lossy-90/${url}`;
+      }.cloudimg.io/crop/${widthParam}x${heightParam}/twebp/${url}`;
     } else {
       return `https://${
         process.env.cloudImageId
-      }.cloudimg.io/width/2560/webp-lossy-90/${url}`;
+      }.cloudimg.io/width/2560/twebp/${url}`;
     }
   };
 

--- a/packages/kauri-web/components/containers/Article/ApprovedArticle/ApprovedArticleHeader.js
+++ b/packages/kauri-web/components/containers/Article/ApprovedArticle/ApprovedArticleHeader.js
@@ -23,7 +23,12 @@ const ApproveArticleHeader = styled(ApprovedArticleSecondaryHeader)`
   padding: 0;
   margin-top: -76px;
   height: inherit;
-  max-height: 290px;
+  @media (max-width: 700px) {
+    max-height: 90vh;
+  }
+  @media (min-width: 700px) {
+    max-height: 300px;
+  }
 `;
 
 const InfoContainer = styled.div`

--- a/packages/kauri-web/components/containers/Collection/View.js
+++ b/packages/kauri-web/components/containers/Collection/View.js
@@ -9,6 +9,7 @@ import CollectionHeader from "../../../../kauri-components/components/Headers/Co
 import CollectionSection from "./CollectionSection";
 import ScrollToTopOnMount from "../../../../kauri-components/components/ScrollToTopOnMount";
 import { Link } from "../../../routes";
+import Image from "../../../../kauri-components/components/Image";
 
 type Props = {
   data: {
@@ -37,13 +38,19 @@ const ContentContainer = styled.div`
 `;
 
 const HeaderContainer = styled(ContentContainer)`
-  background: url(${props => props.background}) center center;
+  background: ${props => props.theme.colors.bgPrimary};
   background-size: cover;
-  margin-top: -76px;
-  padding-top: 106px;
-  padding-bottom: 50px;
   flex-wrap: wrap;
   position: relative;
+  height: inherit;
+  padding: 0;
+  margin-top: -76px;
+  @media (max-width: 700px) {
+    max-height: 90vh;
+  }
+  @media (min-width: 700px) {
+    max-height: 300px;
+  }
 `;
 
 class CollectionPage extends Component<Props, { trianglify: string }> {
@@ -144,8 +151,14 @@ class CollectionPage extends Component<Props, { trianglify: string }> {
           <meta name="twitter:image" content={bg} />
         </Helmet>
         <ScrollToTopOnMount />
-        <HeaderContainer background={bg}>
-          <Overlay />
+        <HeaderContainer>
+          <Image
+            height="100%"
+            width="100%"
+            overlay={{ opacity: 0.5 }}
+            asBackground
+            image={bg}
+          />
           <CollectionHeader
             imageURL={typeof bg === "string" ? bg : null}
             id={id}

--- a/packages/kauri-web/components/containers/Requests/DescriptionRow.js
+++ b/packages/kauri-web/components/containers/Requests/DescriptionRow.js
@@ -592,13 +592,13 @@ export default compose(withErrorCatch())(
                         "https://api.beta.kauri.io:443/ipfs/",
                         `https://${
                           process.env.cloudImageId
-                        }.cloudimg.io/cdn/webp-lossy-90/https://api.beta.kauri.io:443/ipfs/`
+                        }.cloudimg.io/cdn/n/twebp/https://api.beta.kauri.io:443/ipfs/`
                       )
                       .replace(
                         "https://api.kauri.io:443/ipfs/",
                         `https://${
                           process.env.cloudImageId
-                        }.cloudimg.io/cdn/webp-lossy-90/https://api.beta.kauri.io:443/ipfs/`
+                        }.cloudimg.io/cdn/n/twebp/https://api.beta.kauri.io:443/ipfs/`
                       )
                   : JSON.parse(text).markdown
               ),


### PR DESCRIPTION
- force webP image format (indicating a loss level might result in non webp images)
- add empty filter to non resized cdn urls
- use Image comp for collection page
- fix article header on mobile with media queries