### PR TITLE
Change "Learn More" link to "/help" from "/about"

### DIFF
--- a/packages/kauri-components/components/SignupBanner/index.tsx
+++ b/packages/kauri-components/components/SignupBanner/index.tsx
@@ -65,7 +65,7 @@ const SignupBanner: React.FunctionComponent<IProps> = props => (
           border="white"
           color="white"
         >{`Learn more`}</SecondaryButtonComponent>,
-        `/about`
+        `/help`
       )}
     </ViewContainer>
   </SignupBannerStack>


### PR DESCRIPTION
/about doesn't exist, returns 404